### PR TITLE
Updates for dependencies, default_tag changes

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -13,7 +13,7 @@ provider "kubernetes" {
 }
 
 resource "aws_security_group" "eks_msk" {
-  name   = "${local.cluster_name}-msk"
+  name   = "${var.cluster_name}-msk"
   vpc_id = module.vpc.vpc_id
 
 }
@@ -21,8 +21,8 @@ resource "aws_security_group" "eks_msk" {
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
   version         = "~> 18.20"
-  cluster_name    = local.cluster_name
-  cluster_version = "1.22"
+  cluster_name    = var.cluster_name
+  cluster_version = "1.28"
   vpc_id          = module.vpc.vpc_id
   subnet_ids      = module.vpc.private_subnets
   enable_irsa     = true
@@ -32,11 +32,13 @@ module "eks" {
 
   cluster_addons = {
     coredns = {
-      resolve_conflicts = "OVERWRITE"
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
     }
     kube-proxy = {}
     vpc-cni = {
-      resolve_conflicts = "OVERWRITE"
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
     }
   }
   manage_aws_auth_configmap = true
@@ -87,12 +89,12 @@ module "eks" {
   }
 
   node_security_group_tags = {
-    "kubernetes.io/cluster/${local.cluster_name}" = null
+    "kubernetes.io/cluster/${var.cluster_name}" = null
   }
 }
 
 output "cluster_name" {
-  value = local.cluster_name
+  value = var.cluster_name
 }
 
 output "region" {

--- a/aws/irsa.tf
+++ b/aws/irsa.tf
@@ -2,14 +2,14 @@ module "iam_assumable_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "4.24.0"
   create_role                   = true
-  role_name                     = local.cluster_name
+  role_name                     = var.cluster_name
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:${var.service_account_name}"]
 }
 
 resource "aws_iam_policy" "cluster" {
-  name_prefix = local.cluster_name
+  name_prefix = var.cluster_name
   description = "EKS humio policy for cluster"
   policy      = data.aws_iam_policy_document.bucket_policy.json
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,17 +1,17 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.6.0"
   required_providers {
     aws = {
-      version = ">= 2.28.1"
+      version = ">= 5.26.0"
     }
     kubernetes = {
-      version = "~> 2.11"
+      version = "~> 2.23"
     }
     random = {
-      version = "~> 3.1"
+      version = "~> 3.5.1"
     }
     local = {
-      version = "~> 2"
+      version = "~> 2.4.0"
     }
   }
 }
@@ -19,7 +19,7 @@ terraform {
 provider "aws" {
   default_tags {
     tags = {
-      Name          = local.cluster_name
+      Name          = var.cluster_name
       Environment   = var.environment
       App           = "humio"
       DeployVersion = "0.1.0"
@@ -31,15 +31,3 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 data "aws_organizations_organization" "current" {}
-
-locals {
-  cluster_name = "humio-quickstart-${random_string.suffix.result}"
-}
-
-resource "random_string" "suffix" {
-  length  = 4
-  special = false
-  lower   = true
-  upper   = false
-  number  = false
-}

--- a/aws/msk.tf
+++ b/aws/msk.tf
@@ -3,20 +3,26 @@ resource "aws_security_group" "msk" {
 }
 
 resource "aws_kms_key" "kms" {
-  description = "Key for ${local.cluster_name}"
+  description = "Key for ${var.cluster_name}"
 }
 
 resource "aws_msk_cluster" "msk" {
-  cluster_name           = local.cluster_name
+  cluster_name           = var.cluster_name
   kafka_version          = var.kafka_version
   number_of_broker_nodes = var.kafka_instance_count
 
   broker_node_group_info {
     instance_type   = var.kafka_instance_type
-    ebs_volume_size = var.kafka_volume_size
     client_subnets  = module.vpc.private_subnets
     security_groups = [aws_security_group.msk.id]
+    
+    storage_info {
+      ebs_storage_info {
+        volume_size = var.kafka_volume_size
+      }
+    }
   }
+
 
   encryption_info {
     encryption_at_rest_kms_key_arn = aws_kms_key.kms.arn

--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -1,10 +1,18 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket = local.cluster_name
+  bucket = var.cluster_name
 
+}
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
+  bucket = aws_s3_bucket.bucket.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 resource "aws_s3_bucket_acl" "bucket" {
   bucket = aws_s3_bucket.bucket.id
   acl    = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
+
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -49,9 +49,14 @@ variable "service_account_name" {
 
 variable "environment" {
   type    = string
-  default = "Production"
+  default = "development"
 }
 variable "owner" {
   type    = string
   default = "humio"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "humio-quickstart-example"
 }

--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -3,7 +3,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.0"
+  version = "5.1.2"
 
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
@@ -14,12 +14,12 @@ module "vpc" {
   enable_dns_hostnames = true
 
   public_subnet_tags = {
-    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
     "kubernetes.io/role/elb"                      = "1"
   }
 
   private_subnet_tags = {
-    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
     "kubernetes.io/role/internal-elb"             = "1"
   }
 }


### PR DESCRIPTION
Updates for TF version and providers.
The cluster name is no longer is generated and was added as a variable. Computed references like random strings lead to a [TF apply issue](https://github.com/hashicorp/terraform-provider-aws/issues/19583) forcing you to run apply twice.